### PR TITLE
Accepts regex flags

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -153,9 +153,16 @@ function getLabelRegexesMapFromObject(configObject) {
     return labelRegexes;
 }
 function checkRegexes(issue_body, regexes) {
+    var found;
     // If several regex entries are provided we require all of them to match for the label to be applied.
     for (const regEx of regexes) {
-        const found = issue_body.match(regEx);
+        const isRegEx = regEx.match(/^\/(.+)\/(.*)$/);
+        if (isRegEx) {
+            found = issue_body.match(new RegExp(isRegEx[1], isRegEx[2]));
+        }
+        else {
+            found = issue_body.match(regEx);
+        }
         if (!found) {
             return false;
         }

--- a/src/main.ts
+++ b/src/main.ts
@@ -163,10 +163,18 @@ function getLabelRegexesMapFromObject(configObject: any): Map<string, string[]> 
 }
 
 function checkRegexes(issue_body: string, regexes: string[]): boolean {
+  var found;
 
   // If several regex entries are provided we require all of them to match for the label to be applied.
   for (const regEx of regexes) {
-    const found = issue_body.match(regEx)
+    const isRegEx = regEx.match(/^\/(.+)\/(.*)$/)
+
+    if (isRegEx) {
+      found = issue_body.match(new RegExp(isRegEx[1], isRegEx[2]))
+    } else {
+      found = issue_body.match(regEx)
+    }
+
     if (!found) {
       return false;
     }


### PR DESCRIPTION
This pull request allows accept regexp flags, so you can write labeler like:

```
critical:
    - '/(critical|urgent)/i'
```

#9 