### PR TITLE
fix markdown link in contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Please note that this project is released with a [Contributor Code of Conduct][c
 0. [Fork][fork] and clone the repository
 0. Create a new branch: `git checkout -b my-branch-name`
 0. Make your change, add tests, and make sure the tests still pass
-0. Push to your fork and [submit a pull request][pr] ([How to create a pull request](https://help.github.com/en/articles/creating-a-pull-request))
+0. Push to your fork and [submit a pull request](https://help.github.com/en/articles/creating-a-pull-request)
 0. Pat your self on the back and wait for your pull request to be reviewed and merged.
 
 Here are a few things you can do that will increase the likelihood of your pull request being accepted:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Please note that this project is released with a [Contributor Code of Conduct][c
 0. [Fork][fork] and clone the repository
 0. Create a new branch: `git checkout -b my-branch-name`
 0. Make your change, add tests, and make sure the tests still pass
-0. Push to your fork and [submit a pull request][https://help.github.com/en/articles/creating-a-pull-request]
+0. Push to your fork and (submit a pull request)[https://help.github.com/en/articles/creating-a-pull-request]
 0. Pat your self on the back and wait for your pull request to be reviewed and merged.
 
 Here are a few things you can do that will increase the likelihood of your pull request being accepted:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Please note that this project is released with a [Contributor Code of Conduct][c
 0. [Fork][fork] and clone the repository
 0. Create a new branch: `git checkout -b my-branch-name`
 0. Make your change, add tests, and make sure the tests still pass
-0. Push to your fork and (submit a pull request)[https://help.github.com/en/articles/creating-a-pull-request]
+0. Push to your fork and [submit a pull request][pr] ([How to create a pull request](https://help.github.com/en/articles/creating-a-pull-request))
 0. Pat your self on the back and wait for your pull request to be reviewed and merged.
 
 Here are a few things you can do that will increase the likelihood of your pull request being accepted:


### PR DESCRIPTION
I'm not sure why the fork and pr links to the actions/github repo so I kept it like that

for the link to docs, let me know if there is a better way to do it