### PR TITLE
Tolerate empty issue body

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -14,7 +14,7 @@ async function run() {
     const issue_number = getIssueNumber();
     const issue_body = getIssueBody();
 
-    if (!issue_number || !issue_body) {
+    if (issue_number === undefined || issue_body === undefined) {
       console.log('Could not get issue number or issue body from context, exiting');
       return;
     }


### PR DESCRIPTION
Previously the code was checking whether `issue_body` was falsy.
The empty string is considered falsy, which would make this Action
fail when the issue body was empty.  Instead, explictly compare
against `undefined` and tolerate issues with empty bodies.

Fixes #33