### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -109,7 +109,7 @@ function getIssueBody() {
 }
 function regexifyConfigPath(configPath, version) {
     var lastIndex = configPath.lastIndexOf('.');
-    return `${configPath.substr(0, lastIndex)}-v${version}.yml`;
+    return `${configPath.substring(0, lastIndex)}-v${version}.yml`;
 }
 function getLabelRegexes(client, configurationPath) {
     return __awaiter(this, void 0, void 0, function* () {

--- a/src/main.ts
+++ b/src/main.ts
@@ -106,7 +106,7 @@ function getIssueBody(): string | undefined {
 
 function regexifyConfigPath(configPath: string, version: string) {
   var lastIndex = configPath.lastIndexOf('.')
-  return `${configPath.substr(0, lastIndex)}-v${version}.yml`
+  return `${configPath.substring(0, lastIndex)}-v${version}.yml`
 }
 
 async function getLabelRegexes(


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.substring()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.