### PR TITLE
Add 'sync-labels' input to optionally not remove labels (#12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,3 +120,21 @@ jobs:
         enable-versioned-regex: 0
         include-title: 1
 ```
+
+### Syncing Labels
+
+By default, labels that no longer match are removed from the issue. To disable this functionality, explicity
+set `sync-labels` to `0`.
+
+```
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: github/issue-labeler@v2.0
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        configuration-path: .github/labeler.yml
+        enable-versioned-regex: 0
+        sync-labels: 0
+```

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,10 @@ inputs:
     description: 'Include the title in addition to the body in the regex target'
     required: false
     default: "0"
+  sync-labels:
+    description: 'Remove labels from issue if regex does not match'
+    required: false
+    default: 1
 runs:
   using: 'node12'
   main: 'lib/main.js'

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,7 +1,11 @@
 "use strict";
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
-    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
 }) : (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     o[k2] = m[k];
@@ -42,6 +46,7 @@ function run() {
             const notBefore = Date.parse(core.getInput('not-before', { required: false }));
             const bodyMissingRegexLabel = core.getInput('body-missing-regex-label', { required: false });
             const includeTitle = parseInt(core.getInput('include-title', { required: false }));
+            const syncLabels = parseInt(core.getInput('sync-labels', { required: false }));
             const issue_number = getIssueOrPullRequestNumber();
             if (issue_number === undefined) {
                 console.log('Could not get issue or pull request number from context, exiting');
@@ -109,10 +114,12 @@ function run() {
                 console.log(`Adding labels ${addLabel.toString()} to issue #${issue_number}`);
                 addLabels(client, issue_number, addLabel);
             }
-            removeLabelItems.forEach(function (label, index) {
-                console.log(`Removing label ${label} from issue #${issue_number}`);
-                removeLabel(client, issue_number, label);
-            });
+            if (syncLabels) {
+                removeLabelItems.forEach(function (label, index) {
+                    console.log(`Removing label ${label} from issue #${issue_number}`);
+                    removeLabel(client, issue_number, label);
+                });
+            }
         }
         catch (error) {
             core.error(error);

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,7 @@ async function run() {
     const notBefore = Date.parse(core.getInput('not-before', { required: false }));
     const bodyMissingRegexLabel = core.getInput('body-missing-regex-label', { required: false });
     const includeTitle = parseInt(core.getInput('include-title', { required: false }));
+    const syncLabels = parseInt(core.getInput('sync-labels', { required: false }));
 
     const issue_number = getIssueOrPullRequestNumber();
     if (issue_number === undefined) {
@@ -93,10 +94,12 @@ async function run() {
       addLabels(client, issue_number, addLabel)
     }
 
-    removeLabelItems.forEach(function (label, index) {
-      console.log(`Removing label ${label} from issue #${issue_number}`)
-      removeLabel(client, issue_number, label)
-    });
+    if (syncLabels) {
+      removeLabelItems.forEach(function (label, index) {
+        console.log(`Removing label ${label} from issue #${issue_number}`)
+        removeLabel(client, issue_number, label)
+      });
+    }
   } catch (error) {
     core.error(error);
     core.setFailed(error.message);


### PR DESCRIPTION
Add an input `sync-labels` that defaults to `1` and maintains current behavior when not set.

When this input is explicitly set to 0, labels with non-matching regexes are not removed.

Closes #12.

