### PR TITLE
Fix pull_request event typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ The labeler action is also available for pull requests. Make sure the workflow i
 
 ```
 on:
-  pull_requests:
+  pull_request:
     types: [opened, edited]
 ```
 


### PR DESCRIPTION
The event is called pull_request but the example shows pull_requests.