### PR TITLE
Feature: Add disable-remove-labels option.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,10 @@ inputs:
     description: 'Include the title in addition to the body in the regex target'
     required: false
     default: "0"
+  disable-remove-labels:
+    description: 'Disable removing labels that are not in the configuration file'
+    required: false
+    default: "0"
 runs:
   using: 'node16'
   main: 'lib/index.js'

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,6 +20,7 @@ async function run() {
     required: false,
   });
   const includeTitle = parseInt(getInput("include-title", { required: false }));
+  const disableRemoveLabels = parseInt(getInput("disable-remove-labels", { required: false }));
 
   const issue_number = getIssueOrPRNumber();
   if (issue_number === undefined) {
@@ -100,9 +101,11 @@ async function run() {
     promises.push(addLabels(client, issue_number, addLabel));
   }
 
-  await Promise.all(
-    promises.concat(removeLabelItems.map(removeLabel(client, issue_number)))
-  );
+  if (removeLabelItems.length && disableRemoveLabels !== 1) {
+    await Promise.all(
+      promises.concat(removeLabelItems.map(removeLabel(client, issue_number)))
+    );
+  }
 }
 
 function getIssueOrPRNumber() {


### PR DESCRIPTION
Added a disable-remove-labels option. When you enable this option, labels will only be added to issues/pull requests and not automatically removed if the regex is not found.