### PR TITLE
fix: read default token

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,14 @@ critical:
 
 Create a workflow (eg: `.github/workflows/labeler.yml` see [Creating a Workflow file](https://help.github.com/en/articles/configuring-a-workflow#creating-a-workflow-file)) to utilize the labeler action with content:
 
-```
+```yml
 name: "Issue Labeler"
 on:
   issues:
     types: [opened, edited]
+
+permissions:
+  issues: write
 
 jobs:
   triage:
@@ -42,7 +45,6 @@ jobs:
     steps:
     - uses: github/issue-labeler@v2.5 #May not be the latest version
       with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
         configuration-path: .github/labeler.yml
         not-before: 2020-01-15T02:54:32Z
         enable-versioned-regex: 0
@@ -50,16 +52,13 @@ jobs:
 
 `not-before` is optional and will result in any issues prior to this timestamp to be ignored.
 
-_Note: The above workflow grants access to the `GITHUB_TOKEN` so the action can make calls to GitHub's REST API._
-
-
 ### Example using versioned issue templates
 
 As you iterate on your regular expressions, since maybe your issue template gets updated, this can have an impact on existing issues. The below allows you to version your regular expression definitions and pair them with issue templates.
 
 Below is the body of an example issue which has the version identifier `issue_labeler_regex_version` embedded.
 
-```
+```md
 <!--
 issue_labeler_regex_version=1
 --!>
@@ -69,11 +68,14 @@ I have an urgent issue that requires someone's attention.
 
 Below is the workflow file
 
-```
+```yml
 name: "Issue Labeler"
 on:
   issues:
     types: [opened, edited]
+
+permissions:
+  issues: write
 
 jobs:
   triage:
@@ -81,7 +83,6 @@ jobs:
     steps:
     - uses: github/issue-labeler@v2.5 #May not be the latest version
       with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
         configuration-path: .github/labeler.yml
         not-before: 2020-01-15T02:54:32Z
         enable-versioned-regex: 1
@@ -101,7 +102,7 @@ Set `body-missing-regex-label` to the name of the label that should be added to 
 
 The labeler action is also available for pull requests. Make sure the workflow is triggered by pull requests.
 
-```
+```yml
 on:
   pull_request:
     types: [opened, edited]
@@ -111,11 +112,14 @@ on:
 
 Set `include-title` to `1` to include the issue title in addition to the body in the regular expression target.
 
-```
+```yml
 name: "Issue Labeler"
 on:
   issues:
     types: [opened, edited]
+
+permissions:
+  issues: write
 
 jobs:
   triage:
@@ -123,7 +127,6 @@ jobs:
     steps:
     - uses: github/issue-labeler@v2.5 #May not be the latest version
       with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
         configuration-path: .github/labeler.yml
         enable-versioned-regex: 0
         include-title: 1
@@ -134,14 +137,13 @@ jobs:
 By default, labels that no longer match are not removed from the issue. To enable this functionality, explicity
 set `sync-labels` to `1`.
 
-```
+```yml
 jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
     - uses: github/issue-labeler@v2.0
       with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
         configuration-path: .github/labeler.yml
         enable-versioned-regex: 0
         sync-labels: 1

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,8 @@ author: 'GitHub'
 inputs:
   repo-token:
     description: 'The GITHUB_TOKEN secret'
-    required: true
+    required: false
+    default: '${{ github.token }}'
   configuration-path:
     description: 'Path to the labeler.yml configuration file'
     required: true


### PR DESCRIPTION
This PR allows the action to read the token by default, so that the user doesn't have to enter the input manually.
I've also added info about the required permissions for tokens, following the new permission scopes.

Closes #65 