### PR TITLE
fix: Use the correct input name so the default applies

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,7 @@ inputs:
     description: 'Remove the label from the issue if the label regex does not match'
     required: false
     default: "0"
-  issue_number:
+  issue-number:
     description: 'The number of the issue/PR to label'
     required: false
     default: ${{ github.event.issue.number || github.event.pull_request.number }}


### PR DESCRIPTION
When upgrading to the new version of this action, I noticed a failure due to the input not having the same name in the `action.yml` that is read by the action. This aligns them.